### PR TITLE
fixed typo "timetrids" to "timegrids"

### DIFF
--- a/hydpy/core/sequencetools.py
+++ b/hydpy/core/sequencetools.py
@@ -993,7 +993,7 @@ class IOSequence(Sequence):
     def save_ext(self):
         """Write the internal data into an external data file."""
         if self.filetype_ext == 'npy':
-            series = pub.timetrids.init.array2series(self.values)
+            series = pub.timegrids.init.array2series(self.values)
             numpy.save(self.filepath_ext, series)
         else:
             with open(self.filepath_ext, 'w') as file_:


### PR DESCRIPTION
fixeda little typo, see above.